### PR TITLE
Add output-json parameter to publish command for use by downstream pr…

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -121,11 +121,17 @@ cli.add_command(import_template)
     help="The namespace you wish to target (e.g. tpp-prod, tpp-dev, tpp-staging).",
 )
 @click.option("--group-name", required=True, help="Name of the Quicksight User Group")
+@click.option(
+    "--output-json",
+    required=True,
+    help="The file path to which operation output should be written as json",
+)
 def publish_dashboard(
     aws_account_id: str,
     template_id: str,
     target_namespace: str,
     group_name: str,
+    output_json: str,
 ):
     """
     Create/Update a dashboard from a template
@@ -141,6 +147,7 @@ def publish_dashboard(
         template_id=template_id,
         target_namespace=target_namespace,
         group_name=group_name,
+        output_json=output_json,
     ).execute()
     log.info(result)
 

--- a/core/operation/publish_dashboard_from_template.py
+++ b/core/operation/publish_dashboard_from_template.py
@@ -10,11 +10,18 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
     """
 
     def __init__(
-        self, template_id: str, target_namespace: str, group_name: str, *args, **kwargs
+        self,
+        template_id: str,
+        target_namespace: str,
+        group_name: str,
+        output_json: str,
+        *args,
+        **kwargs,
     ):
         self._template_id = template_id
         self._target_namespace = target_namespace
         self._group_name = group_name
+        self._output_json = output_json
         super().__init__(*args, **kwargs)
 
     def execute(self) -> dict:
@@ -110,11 +117,17 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
                 f"Unexpected response from trying to update_dashboard_permissions : {json.dumps(response, indent=4)} "
             )
 
-        return {
+        result = {
             "status": "success",
             "dashboard_arn": dashboard_arn,
             "dashboard_id": dashboard_id,
         }
+
+        with open(self._output_json, "w") as output:
+            output.write(json.dumps(result))
+            self._log.info(f"Output written to {self._output_json}")
+
+        return result
 
     def _create_or_update_dashboard(self, dashboard_params: dict) -> tuple[str, str]:
         """


### PR DESCRIPTION
…ocesses.

## Description

Outputting operation results to json is useful for downstream processes that need to make use of that information such as dashboard ARNs.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-516

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Yes. Covered by unit test.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ / ] I have updated the documentation accordingly.
- [ / ] All new and existing tests passed.
