### PR TITLE
Add option to upload result to s3

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -20,11 +20,14 @@ log = logging.getLogger("core.cli")
 
 boto3.setup_default_session()
 
+
 def create_quicksight_client():
     return boto3.client("quicksight")
 
+
 def create_s3_client():
     return boto3.client("s3")
+
 
 @click.group()
 def cli():
@@ -112,7 +115,6 @@ def import_template(
 cli.add_command(import_template)
 
 
-
 @click.command
 @click.option("--aws-account-id", required=True, help="The ID of the AWS account")
 @click.option(
@@ -127,16 +129,17 @@ cli.add_command(import_template)
 @click.option(
     "--output-json",
     required=False,
-    help="The file path to which operation output should be written as json",)
+    help="The file path to which operation output should be written as json",
+)
 @click.option(
     "--result-bucket",
     required=False,
-    help="An S3 bucket to save the results to. If specified, you must also specify a result-key"
+    help="An S3 bucket to save the results to. If specified, you must also specify a result-key",
 )
 @click.option(
     "--result-key",
     required=False,
-    help="An S3 object key to save the results to. If used, result-bucket must be specified."
+    help="An S3 object key to save the results to. If used, result-bucket must be specified.",
 )
 def publish_dashboard(
     aws_account_id: str,
@@ -144,8 +147,8 @@ def publish_dashboard(
     target_namespace: str,
     group_name: str,
     output_json: str,
-    result_bucket:str,
-    result_key:str,
+    result_bucket: str,
+    result_key: str,
 ):
     """
     Create/Update a dashboard from a template
@@ -170,3 +173,93 @@ def publish_dashboard(
 
 
 cli.add_command(publish_dashboard)
+
+
+@click.command
+@click.option("--aws-account-id", required=True, help="The ID of the AWS account")
+@click.option(
+    "--template-name", required=True, help="The name of the template to be restored"
+)
+@click.option(
+    "--data-source-arn",
+    required=True,
+    help="The ARN of the data source you want to associate with the data sets",
+)
+@click.option(
+    "--target-namespace",
+    required=True,
+    help="The namespace you wish to target (e.g. tpp-prod, tpp-dev, tpp-staging).",
+)
+@click.option(
+    "--input-dir",
+    required=True,
+    help="The path to the input directory from which resources will be imported",
+)
+@click.option("--group-name", required=True, help="Name of the Quicksight User Group")
+@click.option(
+    "--output-json",
+    required=False,
+    help="The file path to which operation output should be written as json",
+)
+@click.option(
+    "--result-bucket",
+    required=False,
+    help="An S3 bucket to save the results to. If specified, you must also specify a result-key",
+)
+@click.option(
+    "--result-key",
+    required=False,
+    help="An S3 object key to save the results to. If used, result-bucket must be specified.",
+)
+def import_and_publish(
+    aws_account_id: str,
+    template_name: str,
+    data_source_arn: str,
+    target_namespace: str,
+    input_dir: str,
+    output_json: str,
+    group_name: str,
+    result_bucket: str,
+    result_key: str,
+):
+
+    log.info(f"import_and_publish")
+    log.info(f"aws_account_id = {aws_account_id}")
+    log.info(f"template_name = {template_name}")
+    log.info(f"data_source_arn = {data_source_arn}")
+    log.info(f"input_dir= {input_dir}")
+    log.info(f"group_name = {group_name}")
+    log.info(f"result_bucket = {result_bucket}")
+    log.info(f"result_key = {result_key}")
+    log.info(f"output_json = {output_json}")
+
+    log.info(f"Importing {template_name}")
+    result = ImportFromJsonOperation(
+        qs_client=create_quicksight_client(),
+        aws_account_id=aws_account_id,
+        template_name=template_name,
+        target_namespace=target_namespace,
+        data_source_arn=data_source_arn,
+        input_dir=input_dir,
+    ).execute()
+    log.info(f"Import result: {result}")
+    template_id: str = result["template"]["id"]
+    log.info(
+        f"Publishing template {template_id} as dashboard using datasource {data_source_arn}"
+    )
+
+    result = PublishDashboardFromTemplateOperation(
+        qs_client=create_quicksight_client(),
+        s3_client=create_s3_client(),
+        aws_account_id=aws_account_id,
+        template_id=template_id,
+        target_namespace=target_namespace,
+        group_name=group_name,
+        result_bucket=result_bucket,
+        result_key=result_key,
+        output_json=output_json,
+    ).execute()
+    log.info(f"publish result = {result}")
+
+
+cli.add_command(import_and_publish)

--- a/core/cli.py
+++ b/core/cli.py
@@ -121,11 +121,17 @@ cli.add_command(import_template)
     help="The namespace you wish to target (e.g. tpp-prod, tpp-dev, tpp-staging).",
 )
 @click.option("--group-name", required=True, help="Name of the Quicksight User Group")
+@click.option(
+    "--output-json",
+    required=True,
+    help="The file path to which operation output should be written as json",
+)
 def publish_dashboard(
     aws_account_id: str,
     template_id: str,
     target_namespace: str,
     group_name: str,
+    output_json: str,
 ):
     """
     Create/Update a dashboard from a template
@@ -141,6 +147,7 @@ def publish_dashboard(
         template_id=template_id,
         target_namespace=target_namespace,
         group_name=group_name,
+        output_json=output_json,
     ).execute()
     log.info(result)
 

--- a/core/operation/baseoperation.py
+++ b/core/operation/baseoperation.py
@@ -22,10 +22,9 @@ class BaseOperation:
     A base class for AWS based operations.
     """
 
-    def __init__(self, qs_client, s3_client, aws_account_id: str):
+    def __init__(self, qs_client, aws_account_id: str):
         self._aws_account_id = aws_account_id
         self._qs_client = qs_client
-        self._s3_client = s3_client
         self._log = logging.getLogger(self.__class__.__name__)
 
     @abstractmethod

--- a/core/operation/baseoperation.py
+++ b/core/operation/baseoperation.py
@@ -22,9 +22,10 @@ class BaseOperation:
     A base class for AWS based operations.
     """
 
-    def __init__(self, qs_client, aws_account_id: str):
+    def __init__(self, qs_client, s3_client, aws_account_id: str):
         self._aws_account_id = aws_account_id
         self._qs_client = qs_client
+        self._s3_client = s3_client
         self._log = logging.getLogger(self.__class__.__name__)
 
     @abstractmethod

--- a/core/operation/publish_dashboard_from_template.py
+++ b/core/operation/publish_dashboard_from_template.py
@@ -15,6 +15,8 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
         target_namespace: str,
         group_name: str,
         output_json: str,
+        result_bucket: str,
+        result_key: str,
         *args,
         **kwargs,
     ):
@@ -22,6 +24,8 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
         self._target_namespace = target_namespace
         self._group_name = group_name
         self._output_json = output_json
+        self._result_bucket = result_bucket
+        self._result_key = result_key
         super().__init__(*args, **kwargs)
 
     def execute(self) -> dict:
@@ -123,9 +127,17 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
             "dashboard_id": dashboard_id,
         }
 
-        with open(self._output_json, "w") as output:
-            output.write(json.dumps(result))
-            self._log.info(f"Output written to {self._output_json}")
+        json_string = json.dumps(result)
+        if self._output_json:
+            with open(self._output_json, "w") as output:
+                output.write(json_string)
+                self._log.info(f"Output written to {self._output_json}")
+
+        if self._result_bucket and self._result_key:
+            self._s3_client.put_object(
+                Bucket=self._result_bucket,
+                Key=self._result_key,
+                Body=json_string)
 
         return result
 

--- a/core/operation/publish_dashboard_from_template.py
+++ b/core/operation/publish_dashboard_from_template.py
@@ -10,11 +10,18 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
     """
 
     def __init__(
-        self, template_id: str, target_namespace: str, group_name: str, *args, **kwargs
+        self,
+        template_id: str,
+        target_namespace: str,
+        group_name: str,
+        output_json: str,
+        *args,
+        **kwargs,
     ):
         self._template_id = template_id
         self._target_namespace = target_namespace
         self._group_name = group_name
+        self._output_json = output_json
         super().__init__(*args, **kwargs)
 
     def execute(self) -> dict:
@@ -110,11 +117,17 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
                 f"Unexpected response from trying to update_dashboard_permissions : {json.dumps(response, indent=4)} "
             )
 
-        return {
+        result = {
             "status": "success",
             "dashboard_arn": dashboard_arn,
             "dashboard_id": dashboard_id,
         }
+
+        with open(self._output_json, "w") as output:
+            output.write(json.dumps(result))
+            self._log.info(f"Output written to {self._output_json}")
+
+        return result
 
     def _create_or_update_dashboard(self, dashboard_params: dict) -> tuple[str, str]:
         """

--- a/tests/core/operation/test_publish_operation.py
+++ b/tests/core/operation/test_publish_operation.py
@@ -17,7 +17,8 @@ class TestPublishDashboardFromTemplateOperation:
         template_id = f"{target_namespace}-library"
         account = "012345678910"
         group_name = "my_group"
-
+        result_bucket = "result-bucket"
+        result_key = "result-key"
         output_json = tempfile.NamedTemporaryFile()
 
         boto_config = Config(
@@ -28,14 +29,21 @@ class TestPublishDashboardFromTemplateOperation:
             "quicksight", config=boto_config
         )
 
+        s3_client = botocore.session.get_session().create_client(
+            "s3", config=boto_config
+        )
+
+        dashboard_arn = (
+            "arn:aws:quicksight:us-west-2:128682227026:dashboard/tpp-prod-library"
+        )
         describe_template_definition_params = {
             "AwsAccountId": account,
             "TemplateId": template_id,
             "AliasName": "$LATEST",
         }
-        with Stubber(qs_client) as stub:
+        with Stubber(qs_client) as qs_stub, Stubber(s3_client) as s3_stub:
             template_arn = f"arn:aws:quicksight:::template/{target_namespace}-library"
-            stub.add_response(
+            qs_stub.add_response(
                 "describe_template",
                 service_response={
                     "Template": {
@@ -63,7 +71,7 @@ class TestPublishDashboardFromTemplateOperation:
 
             namespace_arn = "arn:quicksight:::namespace/default"
 
-            stub.add_response(
+            qs_stub.add_response(
                 "describe_namespace",
                 service_response={"Namespace": {"Arn": namespace_arn}},
                 expected_params={
@@ -77,7 +85,7 @@ class TestPublishDashboardFromTemplateOperation:
             )
             ds2_arn = f"arn:aws:quicksight:::dataset/{target_namespace}-patron_events"
 
-            stub.add_response(
+            qs_stub.add_response(
                 "describe_data_set",
                 service_response={"DataSet": {"Arn": ds1_arn}},
                 expected_params={
@@ -85,7 +93,7 @@ class TestPublishDashboardFromTemplateOperation:
                     "DataSetId": f"{target_namespace}-circulation_view",
                 },
             )
-            stub.add_response(
+            qs_stub.add_response(
                 "describe_data_set",
                 service_response={"DataSet": {"Arn": ds2_arn}},
                 expected_params={
@@ -94,7 +102,7 @@ class TestPublishDashboardFromTemplateOperation:
                 },
             )
 
-            stub.add_response(
+            qs_stub.add_response(
                 "create_dashboard",
                 service_response={
                     "ResponseMetadata": {
@@ -109,7 +117,7 @@ class TestPublishDashboardFromTemplateOperation:
                         },
                         "RetryAttempts": 0,
                     },
-                    "Arn": "arn:aws:quicksight:us-west-2:128682227026:dashboard/tpp-prod-library",
+                    "Arn": dashboard_arn,
                     "VersionArn": f"arn:aws:quicksight:::dashboard/{target_namespace}-library/version/6",
                     "DashboardId": f"{target_namespace}-library",
                     "CreationStatus": "CREATION_IN_PROGRESS",
@@ -138,7 +146,7 @@ class TestPublishDashboardFromTemplateOperation:
                 },
             )
             group_arn = f"arn:aws:quicksight:::group/{group_name}"
-            stub.add_response(
+            qs_stub.add_response(
                 "describe_group",
                 service_response={"Group": {"Arn": group_arn}},
                 expected_params={
@@ -148,7 +156,7 @@ class TestPublishDashboardFromTemplateOperation:
                 },
             )
 
-            stub.add_response(
+            qs_stub.add_response(
                 "update_dashboard_permissions",
                 service_response={
                     "ResponseMetadata": {
@@ -188,21 +196,37 @@ class TestPublishDashboardFromTemplateOperation:
                     ],
                 },
             )
+
+            s3_stub.add_response(
+                "put_object",
+                service_response={},
+                expected_params={
+                    "Bucket": result_bucket,
+                    "Key": result_key,
+                    "Body": json.dumps({template_id: [dashboard_arn]}),
+                },
+            )
+
             op = PublishDashboardFromTemplateOperation(
                 qs_client=qs_client,
+                s3_client=s3_client,
                 template_id=template_id,
                 target_namespace=target_namespace,
                 aws_account_id=account,
                 group_name=group_name,
                 output_json=output_json.name,
+                result_bucket=result_bucket,
+                result_key=result_key,
             )
 
             result = op.execute()
 
             assert result["status"] == "success"
-            assert result["dashboard_id"] == template_id
+            assert result["dashboard_info"] == {template_id: [dashboard_arn]}
             assert os.path.exists(output_json.name)
 
             with open(output_json.name) as file:
                 result_from_file = json.loads(file.read())
-                assert result_from_file["dashboard_id"] == result["dashboard_id"]
+                assert result_from_file["dashboard_info"] == {
+                    template_id: [dashboard_arn]
+                }


### PR DESCRIPTION
## Description
This PR contains changes to support passing dashboard info generated by terraform driven scripts to downstream ansible scripts.

So this PR adds the ability:
1. to import and publish a dashboard in one operation.
2. to push the results to S3 so they can be used by other downstream processes (ansible playbook)

These features are invoked [here](https://github.com/ThePalaceProject/hosting-playbook/pull/518).
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-516

https://github.com/ThePalaceProject/hosting-playbook/pull/518
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Changes are covered by updates to existing unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
