### PR TITLE
Add refresh schedules and properties to export and import.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 on: [push, pull_request]
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.11
 
 jobs:
   lint:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,7 +1,7 @@
 name: Mypy (Type check)
 on: [push, pull_request]
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.11
 
 jobs:
   mypy:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         module: [Core]
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/core/operation/baseoperation.py
+++ b/core/operation/baseoperation.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 ASSET_DIR = "assets"
 TEMPLATE_DIR = os.path.join(ASSET_DIR, "templates")
 DATA_SET_DIR = os.path.join(ASSET_DIR, "data-sets")
+DATA_SET_REFRESH_PROPS_SUFFIX = "-data-set-refresh-props"
+DATA_SET_REFRESH_SCHEDULES_SUFFIX = "-data-set-refresh-schedules"
 
 
 @dataclass
@@ -102,3 +104,6 @@ class BaseOperation:
 
     def _resolve_path(self, *paths):
         return os.path.join(*paths)
+
+    def _resolve_schedules_filename(self, logical_data_set_name: str):
+        return logical_data_set_name + DATA_SET_REFRESH_SCHEDULES_SUFFIX + ".json"

--- a/core/operation/export_analysis_operation.py
+++ b/core/operation/export_analysis_operation.py
@@ -85,7 +85,7 @@ class ExportAnalysisOperation(BaseOperation):
             map_to_save[i] = self._template_definition[i]
 
         # save the template as json file
-        definition_json_str = json.dumps(map_to_save, indent=4)
+        definition_json_str = json.dumps(map_to_save, indent=4, default=str)
         template_file_path = self._resolve_path(
             self._output_dir, TEMPLATE_DIR, self._template_definition["Name"] + ".json"
         )

--- a/core/operation/publish_dashboard_from_template.py
+++ b/core/operation/publish_dashboard_from_template.py
@@ -144,6 +144,7 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
             self._s3_client.put_object(
                 Bucket=self._result_bucket,
                 Key=self._result_key,
+                ContentType="application/json",
                 Body=json.dumps(result["dashboard_info"]),
             )
 

--- a/tests/core/operation/analysis_test_responses.py
+++ b/tests/core/operation/analysis_test_responses.py
@@ -402,3 +402,37 @@ def describe_data_set_2_response():
         },
         "RequestId": "3e6ad967-c44d-4a86-8391-be51ebf978c5",
     }
+
+
+def describe_refresh_props_response():
+    return {
+        "DataSetRefreshProperties": {
+            "RefreshConfiguration": {
+                "IncrementalRefresh": {
+                    "LookbackWindow": {
+                        "ColumnName": "time_stamp",
+                        "Size": 1,
+                        "SizeUnit": "DAY",
+                    }
+                }
+            }
+        }
+    }
+
+
+def list_refresh_schedules_response():
+    return {
+        "RefreshSchedules": [
+            {
+                "ScheduleId": "fcdd5fe8-537d-4e59-947e-af35b5a82385",
+                "ScheduleFrequency": {
+                    "Interval": "DAILY",
+                    "Timezone": "America/New_York",
+                    "TimeOfTheDay": "23:59",
+                },
+                "StartAfterDateTime": "2023-09-29 16:59:00-07:00",
+                "RefreshType": "INCREMENTAL_REFRESH",
+                "Arn": "arn:aws:quicksight:us-west-2:128682227026:dataset/e9e15c78-0193-4e4c-9a49-ed005569297d/refresh-schedule/fcdd5fe8-537d-4e59-947e-af35b5a82385",
+            }
+        ]
+    }

--- a/tests/core/operation/resources/assets/data-sets/circulation_view-data-set-refresh-props.json
+++ b/tests/core/operation/resources/assets/data-sets/circulation_view-data-set-refresh-props.json
@@ -1,0 +1,11 @@
+{
+    "RefreshConfiguration": {
+        "IncrementalRefresh": {
+            "LookbackWindow": {
+                "ColumnName": "time_stamp",
+                "Size": 1,
+                "SizeUnit": "DAY"
+            }
+        }
+    }
+}

--- a/tests/core/operation/resources/assets/data-sets/circulation_view-data-set-refresh-schedules.json
+++ b/tests/core/operation/resources/assets/data-sets/circulation_view-data-set-refresh-schedules.json
@@ -1,0 +1,12 @@
+{
+    "RefreshSchedules": [
+        {
+            "ScheduleFrequency": {
+                "Interval": "DAILY",
+                "Timezone": "UTC",
+                "TimeOfTheDay": "07:00"
+            },
+            "RefreshType": "INCREMENTAL_REFRESH"
+        }
+    ]
+}

--- a/tests/core/operation/test_publish_operation.py
+++ b/tests/core/operation/test_publish_operation.py
@@ -212,6 +212,7 @@ class TestPublishDashboardFromTemplateOperation:
                 expected_params={
                     "Bucket": result_bucket,
                     "Key": result_key,
+                    "ContentType": "application/json",
                     "Body": json.dumps({template_id: [dashboard_arn]}),
                 },
             )


### PR DESCRIPTION
## Description

In order to keep the Development version and deployed versions of the Quicksight Dashboards in sync, we needed to add refresh properties and schedules to the export/import process.  This update adds the following: 

1. Exports data set refresh properties to json.
2. Exports the data set refresh schedule(s) to json
3. Deletes any existing data set refresh properties and schedules on existing data sets before attempting to recreate the data sets
4. creates  data set refresh properties and schedules that were found among the resources.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-603

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been updated to include this functionality and it has been manually tested as well.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [] I have updated the documentation accordingly.
- [] All new and existing tests passed.
