### PR TITLE
Wait for dashboard creation before granting permissions (PP-4946)

### DIFF
--- a/core/operation/publish_dashboard_from_template.py
+++ b/core/operation/publish_dashboard_from_template.py
@@ -85,8 +85,9 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
             dashboard_params=parameters
         )
 
-        # pause for a moment to allow the updates to be processed.
-        time.sleep(3)
+        # updating permissions while the dashboard is still being created fails
+        # with a ConflictException, so wait for creation to finish first.
+        self._wait_for_dashboard(dashboard_id=dashboard_id)
 
         # Grant permissions
         # resolve readers group
@@ -129,9 +130,9 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
         result = {
             "status": "success",
             "dashboard_info": {
-                self._dashboard_alias
-                if self._dashboard_alias
-                else self._template_id: [dashboard_arn]
+                self._dashboard_alias if self._dashboard_alias else self._template_id: [
+                    dashboard_arn
+                ]
             },
         }
 
@@ -178,3 +179,33 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
             )
         else:
             return response["Arn"], response["DashboardId"]
+
+    # create_dashboard/update_dashboard return while the dashboard version is
+    # still building, so poll until it reaches a terminal status.
+    DASHBOARD_STATUS_POLL_INTERVAL_SECONDS = 3
+    DASHBOARD_STATUS_MAX_POLLS = 40
+
+    def _wait_for_dashboard(self, dashboard_id: str) -> None:
+        """
+        Blocks until the dashboard version reaches a terminal status.
+        :param dashboard_id:
+        """
+        for _ in range(self.DASHBOARD_STATUS_MAX_POLLS):
+            response = self._qs_client.describe_dashboard(
+                AwsAccountId=self._aws_account_id, DashboardId=dashboard_id
+            )
+            status = response["Dashboard"]["Version"]["Status"]
+            if status.endswith("_SUCCESSFUL"):
+                return
+            if status.endswith("_FAILED"):
+                raise Exception(
+                    f"Dashboard ({dashboard_id}) failed to publish: status = {status}"
+                )
+            self._log.info(
+                f"Dashboard ({dashboard_id}) not ready yet: status = {status}"
+            )
+            time.sleep(self.DASHBOARD_STATUS_POLL_INTERVAL_SECONDS)
+        raise Exception(
+            f"Dashboard ({dashboard_id}) did not reach a terminal status after "
+            f"{self.DASHBOARD_STATUS_MAX_POLLS * self.DASHBOARD_STATUS_POLL_INTERVAL_SECONDS} seconds"
+        )

--- a/core/operation/publish_dashboard_from_template.py
+++ b/core/operation/publish_dashboard_from_template.py
@@ -130,9 +130,9 @@ class PublishDashboardFromTemplateOperation(BaseOperation):
         result = {
             "status": "success",
             "dashboard_info": {
-                self._dashboard_alias if self._dashboard_alias else self._template_id: [
-                    dashboard_arn
-                ]
+                self._dashboard_alias
+                if self._dashboard_alias
+                else self._template_id: [dashboard_arn]
             },
         }
 

--- a/tests/core/operation/test_publish_operation.py
+++ b/tests/core/operation/test_publish_operation.py
@@ -1,6 +1,7 @@
 import json
 import os.path
 import tempfile
+from unittest.mock import patch
 
 import botocore
 from botocore.config import Config
@@ -154,6 +155,23 @@ class TestPublishDashboardFromTemplateOperation:
                     },
                 },
             )
+            # the operation polls until the dashboard version reaches a
+            # terminal status before granting permissions
+            for status in ["CREATION_IN_PROGRESS", "CREATION_SUCCESSFUL"]:
+                qs_stub.add_response(
+                    "describe_dashboard",
+                    service_response={
+                        "Dashboard": {
+                            "DashboardId": template_id,
+                            "Version": {"Status": status},
+                        }
+                    },
+                    expected_params={
+                        "AwsAccountId": account,
+                        "DashboardId": template_id,
+                    },
+                )
+
             group_arn = f"arn:aws:quicksight:::group/{group_name}"
             qs_stub.add_response(
                 "describe_group",
@@ -229,7 +247,12 @@ class TestPublishDashboardFromTemplateOperation:
                 result_key=result_key,
             )
 
-            result = op.execute()
+            with patch(
+                "core.operation.publish_dashboard_from_template.time.sleep"
+            ) as sleep_mock:
+                result = op.execute()
+
+            sleep_mock.assert_called_once()
 
             assert result["status"] == "success"
             assert result["dashboard_info"] == {template_id: [dashboard_arn]}


### PR DESCRIPTION
## Description

`publish-dashboard` now polls `describe_dashboard` after creating/updating the dashboard, and only proceeds to grant permissions once the dashboard version reaches a terminal status (`*_SUCCESSFUL`; raises on `*_FAILED` or after a 2-minute timeout). Replaces the fixed 3-second sleep.

## Motivation

Follow-up from [PP-4946](https://ebce-lyrasis.atlassian.net/browse/PP-4946). During the 2026-08-12 production deploy, the dashboard was still `CREATION_IN_PROGRESS` three seconds after `CreateDashboard`, so the subsequent `UpdateDashboardPermissions` call failed with `ConflictException: concurrent modification` — leaving the dashboard published but unreadable (no viewer permissions) until manually re-granted. Waiting for the terminal status removes the race entirely.

[PP-4946]: https://ebce-lyrasis.atlassian.net/browse/PP-4946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ