### PR TITLE
Start dataset refresh schedules promptly after deploy (PP-4946)

### DIFF
--- a/core/operation/import_from_json_operation.py
+++ b/core/operation/import_from_json_operation.py
@@ -183,8 +183,16 @@ class ImportFromJsonOperation(BaseOperation):
             delete_params.update({"ScheduleId": schedule_id})
             self._qs_client.delete_refresh_schedule(**delete_params)
 
-    def _get_tomorrow(self) -> datetime.datetime:
-        return datetime.datetime.now() + datetime.timedelta(days=1)
+    def _get_schedule_start_after(self) -> datetime.datetime:
+        # The API requires StartAfterDateTime to be in the future, but any
+        # padding delays the schedule's first run past every scheduled firing
+        # time inside it (a day of padding skips a full day of refreshes), so
+        # keep it small. It must also be timezone-aware: boto3 serializes naive
+        # datetimes as if they were UTC, which on machines west of UTC would
+        # produce a timestamp in the past.
+        return datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
+            minutes=10
+        )
 
     def _create_refresh_schedule(self, logical_data_set_name: str, data_set_id: str):
         params = {
@@ -217,8 +225,7 @@ class ImportFromJsonOperation(BaseOperation):
                 schedules = json.loads(dataset_refresh_file.read())["RefreshSchedules"]
 
                 for index, schedule in enumerate(schedules):
-                    start_after_datetime = self._get_tomorrow()
-                    # start after date must be in the future
+                    start_after_datetime = self._get_schedule_start_after()
                     schedule["ScheduleId"] = data_set_id + "-" + str(index)
                     schedule["StartAfterDateTime"] = start_after_datetime
                     schedule_params = {"Schedule": schedule}

--- a/core/operation/import_from_json_operation.py
+++ b/core/operation/import_from_json_operation.py
@@ -187,9 +187,7 @@ class ImportFromJsonOperation(BaseOperation):
         # The API requires StartAfterDateTime to be in the future, but any
         # padding delays the schedule's first run past every scheduled firing
         # time inside it (a day of padding skips a full day of refreshes), so
-        # keep it small. It must also be timezone-aware: boto3 serializes naive
-        # datetimes as if they were UTC, which on machines west of UTC would
-        # produce a timestamp in the past.
+        # keep it small.
         return datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
             minutes=10
         )

--- a/tests/core/operation/test_import_template_operation.py
+++ b/tests/core/operation/test_import_template_operation.py
@@ -216,12 +216,12 @@ class TestImportTemplateOperation:
         sess = Session()
         qs_client = sess.create_client("quicksight", config=boto_config)
 
-        this_time_tomorrow = datetime.datetime.now()
+        schedule_start_after = datetime.datetime.now()
         with Stubber(qs_client) as stub, patch(
-            "core.operation.import_from_json_operation.ImportFromJsonOperation._get_tomorrow"
+            "core.operation.import_from_json_operation.ImportFromJsonOperation._get_schedule_start_after"
         ) as dt:
 
-            dt.return_value = this_time_tomorrow
+            dt.return_value = schedule_start_after
             stub.add_response(
                 "delete_template",
                 service_response={},
@@ -322,7 +322,7 @@ class TestImportTemplateOperation:
                             "Timezone": "UTC",
                             "TimeOfTheDay": "07:00",
                         },
-                        "StartAfterDateTime": this_time_tomorrow,
+                        "StartAfterDateTime": schedule_start_after,
                         "RefreshType": "INCREMENTAL_REFRESH",
                     },
                 },


### PR DESCRIPTION
## Description

Refresh schedules created by `import-and-publish` now get a `StartAfterDateTime` of **now + 10 minutes (timezone-aware UTC)** instead of a naive **now + 1 day**.

## Motivation

Follow-up from [PP-4946](https://ebce-lyrasis.atlassian.net/browse/PP-4946). The +1 day padding pushed each schedule's first eligible run past the next day's firing time, so every dashboard deploy silently skipped a full day of dataset refreshes (observable in the ingestion history: no refresh on the day after any deploy).

[PP-4946]: https://ebce-lyrasis.atlassian.net/browse/PP-4946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ